### PR TITLE
Prevent usage of deprecated dynamic property

### DIFF
--- a/Block/Widget/Grid/Column/Renderer/Time.php
+++ b/Block/Widget/Grid/Column/Renderer/Time.php
@@ -60,12 +60,6 @@ class Time extends AbstractRenderer
         $ago  = new DateTime($datetime);
         $diff = $now->diff($ago);
 
-        if ($diff->d >= 7) {
-            $diff->w = floor($diff->d / 7);
-            $diff->d -= $diff->w * 7;
-            $string[] = ['w' => 'week'];
-        }
-
         $string = [
             'y' => 'year',
             'm' => 'month',


### PR DESCRIPTION
To prevent the dynamic declaration of a property (in this case (new DateTime())->w) we have fully removed the support of storing and displaying week diff data

<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes mageplaza/magento-2-smtp#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

